### PR TITLE
fix: confirm EVM mint before completion

### DIFF
--- a/src/hooks/use-cross-chain-transfer.ts
+++ b/src/hooks/use-cross-chain-transfer.ts
@@ -558,7 +558,15 @@ export function useCrossChainTransfer() {
           gas: gasWithBuffer,
         });
 
-        addLog(`Mint Tx: ${tx}`);
+        addLog(`Mint Tx submitted: ${tx}`);
+        const receipt = await publicClient.waitForTransactionReceipt({
+          hash: tx,
+        });
+        if (receipt.status !== "success") {
+          throw new Error(`Mint transaction reverted: ${tx}`);
+        }
+
+        addLog(`Mint Tx confirmed: ${tx}`);
         setCurrentStep("completed");
         break;
       } catch (err) {
@@ -568,6 +576,7 @@ export function useCrossChainTransfer() {
           await new Promise((resolve) => setTimeout(resolve, MINT_RETRY_BASE_DELAY_MS * retries));
           continue;
         }
+        setError("Mint failed");
         throw err;
       }
     }


### PR DESCRIPTION
The EVM mint path currently marks a transfer as completed as soon as the wallet returns a transaction hash. If `receiveMessage` later reverts, the UI still reports a successful cross-chain transfer even though USDC was not minted.

This waits for the destination-chain receipt before completing the flow, reports a reverted receipt as a mint failure, and distinguishes submitted and confirmed transactions in the transfer log. The Solana path is unchanged because Anchor's `.rpc()` already confirms the transaction.

Checked with:
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`