### PR TITLE
fix(cctp): correct depositForBurn ABI parameter names

### DIFF
--- a/src/hooks/use-cross-chain-transfer.ts
+++ b/src/hooks/use-cross-chain-transfer.ts
@@ -82,6 +82,8 @@ const MINT_MAX_RETRIES = 3;
 const MINT_RETRY_BASE_DELAY_MS = 2000;
 const GAS_BUFFER_PERCENT = 120n;
 const FAST_FEE_BUFFER_PERCENT = 120n;
+// Passed as `destinationCaller`: bytes32(0) means any address may call
+// receiveMessage on the destination chain.
 const BYTES32_ZERO =
   "0x0000000000000000000000000000000000000000000000000000000000000000" as Hex;
 
@@ -297,9 +299,9 @@ export function useCrossChainTransfer() {
               { name: "destinationDomain", type: "uint32" },
               { name: "mintRecipient", type: "bytes32" },
               { name: "burnToken", type: "address" },
-              { name: "hookData", type: "bytes32" },
+              { name: "destinationCaller", type: "bytes32" },
               { name: "maxFee", type: "uint256" },
-              { name: "finalityThreshold", type: "uint32" },
+              { name: "minFinalityThreshold", type: "uint32" },
             ],
             outputs: [],
           },


### PR DESCRIPTION
The inline EVM depositForBurn ABI labels the 5th parameter `hookData` and the 7th `finalityThreshold`. CCTP v2's actual signature is:

  depositForBurn(uint256 amount, uint32 destinationDomain, bytes32 mintRecipient,
                 address burnToken, bytes32 destinationCaller, uint256 maxFee,
                 uint32 minFinalityThreshold)

`hookData` is a `bytes` argument that exists only on depositForBurnWithHook, so the current names suggest a hook can be passed here when it cannot. The Solana path in this same file already uses `destinationCaller` and `minFinalityThreshold`, so this also makes the two paths consistent.

ABI encoding is derived from types, not names, so behaviour is unchanged. Adds a comment noting that bytes32(0) means any address may call receiveMessage.