### PR TITLE
chore: remove unused .env.example that asks for browser-exposed private keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,0 @@
-# WARNING: These keys are exposed to the browser (NEXT_PUBLIC_ prefix).
-# Use ONLY testnet keys. Never use mainnet keys or keys holding real value.
-NEXT_PUBLIC_EVM_PRIVATE_KEY=your_evm_private_key_here
-NEXT_PUBLIC_SOLANA_PRIVATE_KEY=your_solana_private_key_here


### PR DESCRIPTION


.env.example ships NEXT_PUBLIC_EVM_PRIVATE_KEY and NEXT_PUBLIC_SOLANA_PRIVATE_KEY, but nothing in the app reads them:

  $ grep -rn 'PRIVATE_KEY' src next.config.ts   # no matches

The README states the demo signs with injected user wallets, and no code path loads a key from the environment. The file's only remaining effect is to tell a newcomer to paste a private key into a NEXT_PUBLIC_ variable — which Next.js inlines into the client bundle — for an app that never uses it.

Removing it rather than editing it, since the app requires no environment variables at all.