### PR TITLE
chore: housekeeping and rename ABI params

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,0 @@
-# WARNING: These keys are exposed to the browser (NEXT_PUBLIC_ prefix).
-# Use ONLY testnet keys. Never use mainnet keys or keys holding real value.
-NEXT_PUBLIC_EVM_PRIVATE_KEY=your_evm_private_key_here
-NEXT_PUBLIC_SOLANA_PRIVATE_KEY=your_solana_private_key_here

--- a/src/hooks/use-cross-chain-transfer.ts
+++ b/src/hooks/use-cross-chain-transfer.ts
@@ -82,6 +82,7 @@ const MINT_MAX_RETRIES = 3;
 const MINT_RETRY_BASE_DELAY_MS = 2000;
 const GAS_BUFFER_PERCENT = 120n;
 const FAST_FEE_BUFFER_PERCENT = 120n;
+// A zero destination caller allows any address to call receiveMessage.
 const BYTES32_ZERO =
   "0x0000000000000000000000000000000000000000000000000000000000000000" as Hex;
 
@@ -251,7 +252,7 @@ export function useCrossChainTransfer() {
     if (!client.account) {
       throw new Error("Connect an EVM wallet to continue.");
     }
-    const finalityThreshold =
+    const minFinalityThreshold =
       transferType === "fast"
         ? FAST_FINALITY_THRESHOLD
         : STANDARD_FINALITY_THRESHOLD;
@@ -297,9 +298,9 @@ export function useCrossChainTransfer() {
               { name: "destinationDomain", type: "uint32" },
               { name: "mintRecipient", type: "bytes32" },
               { name: "burnToken", type: "address" },
-              { name: "hookData", type: "bytes32" },
+              { name: "destinationCaller", type: "bytes32" },
               { name: "maxFee", type: "uint256" },
-              { name: "finalityThreshold", type: "uint32" },
+              { name: "minFinalityThreshold", type: "uint32" },
             ],
             outputs: [],
           },
@@ -314,7 +315,7 @@ export function useCrossChainTransfer() {
             .usdcAddress as `0x${string}`,
           BYTES32_ZERO,
           maxFee,
-          finalityThreshold,
+          minFinalityThreshold,
         ],
       }),
     });


### PR DESCRIPTION
This PR:
- removes no longer used .env.example (#142)
- fix ABI input names (#141)