### PR TITLE
fix: add Arc RPC rewrite

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,7 +19,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: "/api/rpc/arc",
+        destination: "https://rpc.testnet.arc.network",
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Arc Testnet is configured to use `/api/rpc/arc` as a same-origin RPC path, but there was no matching Next rewrite, so requests to that endpoint returned the app's 404 page.

Added the rewrite to forward that path to Arc's testnet RPC.

Checked with:
- `npm run lint`
- `npm run build`
- local POST to `/api/rpc/arc` with `eth_chainId`