### PR TITLE
Fix: mint retry loop silently exits without throwing on final failure

### DIFF
--- a/src/hooks/use-cross-chain-transfer.ts
+++ b/src/hooks/use-cross-chain-transfer.ts
@@ -568,7 +568,7 @@ export function useCrossChainTransfer() {
       } catch (err) {
         if (
           err instanceof TransactionExecutionError &&
-          retries < MINT_MAX_RETRIES
+          retries < MINT_MAX_RETRIES - 1
         ) {
           retries++;
           addLog(`Retry ${retries}/${MINT_MAX_RETRIES}...`);


### PR DESCRIPTION
## Bug

`mintEvmUsdc`'s retry loop checks `retries < MINT_MAX_RETRIES` inside the catch block before incrementing. On the final attempt (retries == MINT_MAX_RETRIES - 1), this condition is still true, so `retries` is incremented to `MINT_MAX_RETRIES` and the loop `continue`s, but the outer `while` condition then fails immediately, exiting the loop
without throwing and without setting `currentStep` to `"completed"` or `"error"`.

Result: if all `MINT_MAX_RETRIES` attempts fail with a `TransactionExecutionError` (e.g. gas/nonce issues on testnet, which are common), the UI is left stuck on "Minting USDC..." with no error shown and no way to reset.

## Fix

Check `retries < MINT_MAX_RETRIES - 1` so the last attempt's failure throws immediately instead of looping into a silent exit.

Verified with a standalone repro of the loop logic. Before the fix, 3/3 failures return `undefined` with no error. After the fix, the error is thrown and propagates to the UI's error state as expected.

Also verified `npm run lint` and `npm run build` both pass cleanly.