### PR TITLE
fix(cctp): resolve Solana burn destinationCaller, fee precision, and remote token validation

### DIFF
--- a/src/hooks/use-cross-chain-transfer.ts
+++ b/src/hooks/use-cross-chain-transfer.ts
@@ -398,10 +398,8 @@ export function useCrossChainTransfer() {
       mintRecipient = new PublicKey(hexToBytes(bytes32Address as Hex));
     }
 
-    const evmAddress = `0x${destinationAddress.replace(/^0x/, "")}`;
-    const destinationCaller = new PublicKey(
-      hexToBytes(evmAddressToBytes32(evmAddress) as Hex),
-    );
+    // In CCTP V2, destinationCaller of PublicKey.default (32 zero bytes) allows any relayer or user to call receiveMessage on the destination chain.
+    const destinationCaller = PublicKey.default;
     const maxFee =
       transferType === "fast"
         ? await getBufferedFastTransferFee(
@@ -639,6 +637,12 @@ export function useCrossChainTransfer() {
         }
       }
 
+      if (!remoteTokenAddressHex) {
+        throw new Error(
+          `Unsupported or unknown source domain: ${sourceDomain}. Unable to locate remote USDC address.`,
+        );
+      }
+
       const pdas = await getReceiveMessagePdas(
         { messageTransmitterProgram, tokenMessengerMinterProgram },
         usdcMint,
@@ -869,11 +873,17 @@ export function useCrossChainTransfer() {
     return bufferedFee;
   };
 
-  const parseFeeBps = (minimumFee: number | string) => {
+  const parseFeeBps = (minimumFee: number | string): bigint => {
     const minimumFeeString = String(minimumFee);
+    if (minimumFeeString.includes("e") || minimumFeeString.includes("E")) {
+      const num = Number(minimumFee);
+      return BigInt(Math.max(0, Math.round(num * 100)));
+    }
     const [whole = "0", fraction = ""] = minimumFeeString.split(".");
+    const wholeBigInt = BigInt(whole || "0");
     const paddedFraction = `${fraction}00`.slice(0, 2);
-    return BigInt(`${whole}${paddedFraction}`);
+    const fractionBigInt = BigInt(paddedFraction || "0");
+    return wholeBigInt * 100n + fractionBigInt;
   };
 
   const isSolanaChain = (chainId: number): boolean => {


### PR DESCRIPTION
## Summary

This PR addresses three issues in the CCTP transfer hook (`useCrossChainTransfer`) affecting Solana burns, fee parsing precision, and mint validation:

1. **Fix `destinationCaller` on Solana `depositForBurn` (`burnSolanaUsdc`)**:
   - Previously, `destinationCaller` was constructed by attempting to parse `destinationAddress` as an EVM hex string (`evmAddressToBytes32`). When the destination was Solana (where `destinationAddress` is base58), this produced an invalid byte array and runtime failure.
   - In CCTP V2, `destinationCaller` specifies which address is authorized to call `receiveMessage` on the destination chain. Passing `PublicKey.default` (32 zero bytes) allows permissionless minting and automated relayer (e.g. Iris) execution, matching `BYTES32_ZERO` on the EVM path (`burnEvmUsdc`).

2. **Improve `parseFeeBps` precision & edge-case handling**:
   - Enhanced `parseFeeBps` to safely parse numbers with scientific/exponential notation without crashing on `BigInt()` conversion, and used safe BigInt scaling (`wholeBigInt * 100n + fractionBigInt`) to prevent string concatenation artifacts.

3. **Add remote token address validation guard in `mintSolanaUsdc`**:
   - Added an explicit check and descriptive error if `remoteTokenAddressHex` cannot be resolved for a given source domain before deriving PDAs, preventing cryptic `Invalid public key input` errors from empty buffers.

## Testing & Verification

- Verified `PublicKey.default` matches 32 zero bytes as required by CCTP V2 Anchor program IDL for open `destinationCaller`.
- Verified `parseFeeBps` across varied inputs (`0.5`, `0.05`, `5`, `1.25`, `1e-4`).
- Verified clean git diff with zero regression on other EVM routes.
