### PR TITLE
fix(arc): use Arc Testnet's own RPC instead of a proxy that does not exist

### DIFF
--- a/src/lib/chains.ts
+++ b/src/lib/chains.ts
@@ -78,16 +78,6 @@ export interface ChainConfig {
   destinationDomain: number;
 }
 
-// Same-origin proxy (see next.config.ts). Wallets still need an absolute RPC URL.
-const arcTestnetProxied = defineChain({
-  ...arcTestnet,
-  rpcUrls: {
-    default: {
-      http: ["/api/rpc/arc"],
-    },
-  },
-});
-
 const edgeTestnet = defineChain({
   id: 33431,
   name: "Edge Testnet",
@@ -135,7 +125,7 @@ export const CHAIN_CONFIGS: Record<SupportedChainId, ChainConfig> = {
   },
   [SupportedChainId.ARC_TESTNET]: {
     name: "Arc Testnet",
-    viemChain: arcTestnetProxied,
+    viemChain: arcTestnet,
     usdcAddress: "0x3600000000000000000000000000000000000000",
     tokenMessenger: "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
     messageTransmitter: "0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275",


### PR DESCRIPTION
Arc Testnet points its RPC at a same-origin proxy that is not in the repo:

```ts
// src/lib/chains.ts
// Same-origin proxy (see next.config.ts). Wallets still need an absolute RPC URL.
const arcTestnetProxied = defineChain({
  ...arcTestnet,
  rpcUrls: { default: { http: ["/api/rpc/arc"] } },
});
```

`/api/rpc/arc` appears exactly once in the tree — on the line that declares it. `next.config.ts` is an empty config with no `rewrites`, `src/app/` contains only `favicon.ico`, `globals.css`, `layout.tsx` and `page.tsx` with no `api/` directory, and there is no `route.ts` or `middleware.ts` anywhere. The comment also notes wallets need an absolute URL, and nothing converts it.

## What breaks

**The app's own calls.** Clients are built with `transport: http()`, which has no URL of its own and falls back to `chain.rpcUrls.default.http[0]`:

```ts
// src/hooks/use-cross-chain-transfer.ts:222, :324
await createPublicClient({
  chain: CHAIN_CONFIGS[sourceChainId as SupportedChainId].viemChain,
  transport: http(),
}).waitForTransactionReceipt({ hash: tx });
```

For Arc that resolves to `/api/rpc/arc`, so the receipt wait after approve and after burn posts to a 404.

**Adding the chain to a wallet.** `ensureEvmChain` hands the same array straight to the wallet:

```ts
// src/lib/browser-wallets.ts:152
rpcUrls: chain.rpcUrls.default.http,
```

EIP-3085 expects absolute http(s) URLs there, so a relative path is rejected. This is on the path every EVM transfer takes — `switchEvmWalletToChain` calls it at line 927.

## Why dropping the proxy is the right fix

I checked whether the proxy was working around CORS. It is not needed — the public endpoint answers cross-origin browser requests:

```
$ curl -i -X POST https://rpc.testnet.arc.network \
    -H 'Content-Type: application/json' -H 'Origin: https://example.com' \
    -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'

HTTP/1.1 200 OK
access-control-allow-origin: https://example.com
access-control-allow-methods: GET, POST, OPTIONS
```

So this drops the override and uses viem's own `arcTestnet`, which carries `https://rpc.testnet.arc.network` plus QuickNode and Blockdaemon fallbacks. Every other chain in the file already uses its viem definition directly, so Arc stops being the exception.

If you would rather keep a same-origin proxy, the change to make is the opposite one — add the missing `app/api/rpc/arc/route.ts` and build an absolute URL for the `wallet_addEthereumChain` call. Happy to send that shape instead; I went with the smaller change because the endpoint does not require it.

## Verification

Against `main` at `efc483c`:

```
npx tsc --noEmit    clean
npx eslint src/lib/chains.ts    clean
npx next build      succeeds
```

`defineChain` is still used by three other chains in the file, so the import stays.
