### PR TITLE
fix(chains): use the real Sonic Testnet chain id

### DIFF
--- a/src/lib/chains.ts
+++ b/src/lib/chains.ts
@@ -34,7 +34,7 @@ import {
   polygonAmoy,
   seiTestnet,
   sepolia,
-  sonicTestnet,
+  sonicTestnet as viemSonicTestnet,
   unichainSepolia,
   worldchainSepolia,
   xdcTestnet,
@@ -86,6 +86,13 @@ const arcTestnetProxied = defineChain({
       http: ["/api/rpc/arc"],
     },
   },
+});
+
+// viem's `sonicTestnet` still carries the pre-migration id (64165) while pointing at
+// the RPC that now serves Sonic Testnet, so pin the id this app already uses.
+const sonicTestnet = defineChain({
+  ...viemSonicTestnet,
+  id: SupportedChainId.SONIC_TESTNET,
 });
 
 const edgeTestnet = defineChain({


### PR DESCRIPTION
Sonic Testnet is wired to viem's `sonicTestnet`, whose `id` is still `64165` (the pre-migration Sonic testnet). Everywhere else the app uses `14601`, which is what the chain's own RPC reports today:

```
$ curl -s https://rpc.testnet.soniclabs.com -X POST -H 'content-type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
{"jsonrpc":"2.0","id":1,"result":"0x3909"}   # 14601
```

The two have drifted apart over time: `SupportedChainId.SONIC_TESTNET` moved to `14601` when the app left Sonic Blaze, and the `viemChain` field added later resolves to viem's definition, which still carries the old id. Sonic is the only entry in `CHAIN_CONFIGS` where `viemChain.id` does not equal the key it is stored under.

## What breaks

Every transfer with Sonic Testnet as source or destination, on the first transaction it sends on that chain.

`ensureEvmChain` puts the wallet on `0x3909` (14601) and its own `eth_chainId` check passes, because the hex id comes from `SupportedChainId`. The wallet client, however, is built from `CHAIN_CONFIGS[...].viemChain`, so `approveEvmUsdc` (and `mintEvmUsdc` on the destination side) calls `sendTransaction` with `chain.id === 64165` while the wallet sits on 14601, and viem rejects it before the wallet ever sees the request:

```
ChainMismatchError: The current chain of the wallet (id: 14601) does not match the target chain for the transaction (id: 64165 – Sonic Testnet).
```

`executeTransfer` catches it, so the run ends there with `currentStep` set to `error`: the log's last line is *Approving USDC transfer...* and the message above is rendered under the progress row.

## Repro

`sonic-repro.mts` at the repo root, `npx tsx sonic-repro.mts`:

```ts
import { createWalletClient, custom } from "viem";
import { CHAIN_CONFIGS, SupportedChainId } from "./src/lib/chains";

// 1. Static check: every entry's viemChain.id must match the key it is stored under.
console.log("1) chain id vs viemChain.id");
let mismatches = 0;
for (const key of Object.keys(CHAIN_CONFIGS).map(Number) as SupportedChainId[]) {
  const config = CHAIN_CONFIGS[key];
  if (!config.viemChain) continue; // Solana
  if (config.viemChain.id !== key) {
    mismatches++;
    console.log(`   MISMATCH  ${config.name.padEnd(20)} key=${key} viemChain.id=${config.viemChain.id}`);
  }
}
console.log(`   ${mismatches} mismatch(es)\n`);

// 2. Live check: what the configured RPC actually reports.
const sonic = CHAIN_CONFIGS[SupportedChainId.SONIC_TESTNET];
const rpcUrl = sonic.viemChain!.rpcUrls.default.http[0];
const res = await fetch(rpcUrl, {
  method: "POST",
  headers: { "content-type": "application/json" },
  body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params: [] }),
});
const { result } = await res.json();
console.log("2) live RPC");
console.log(`   ${rpcUrl} -> eth_chainId ${result} (${parseInt(result, 16)})`);
console.log(`   viemChain.id                   ${sonic.viemChain!.id}`);
console.log(`   SupportedChainId.SONIC_TESTNET ${SupportedChainId.SONIC_TESTNET}\n`);

// 3. The approve step, against a wallet that ensureEvmChain has put on Sonic Testnet.
const walletOnSonic = {
  request: async ({ method }: { method: string }) => {
    if (method === "eth_chainId") return "0x3909"; // 14601, what the wallet reports
    if (method === "eth_accounts" || method === "eth_requestAccounts")
      return ["0x1111111111111111111111111111111111111111"];
    if (method === "eth_sendTransaction") return "0xdeadbeef"; // wallet accepts the tx
    throw new Error(`unexpected call: ${method}`);
  },
};

const client = createWalletClient({
  account: "0x1111111111111111111111111111111111111111",
  chain: sonic.viemChain,
  transport: custom(walletOnSonic),
});

console.log("3) approve step against a wallet on Sonic Testnet");
try {
  await client.sendTransaction({
    account: client.account!,
    chain: client.chain,
    to: sonic.usdcAddress as `0x${string}`,
    data: "0x095ea7b3",
  });
  console.log("   sent (no error)");
} catch (err) {
  console.log(`   ${(err as Error).message.split("\n").slice(0, 4).join("\n   ")}`);
}
```

Before:

```
1) chain id vs viemChain.id
   MISMATCH  Sonic Testnet        key=14601 viemChain.id=64165
   1 mismatch(es)

2) live RPC
   https://rpc.testnet.soniclabs.com -> eth_chainId 0x3909 (14601)
   viemChain.id                   64165
   SupportedChainId.SONIC_TESTNET 14601

3) approve step against a wallet on Sonic Testnet
   The current chain of the wallet (id: 14601) does not match the target chain for the transaction (id: 64165 – Sonic Testnet).

   Current Chain ID:  14601
   Expected Chain ID: 64165 – Sonic Testnet
```

After:

```
1) chain id vs viemChain.id
   0 mismatch(es)

2) live RPC
   https://rpc.testnet.soniclabs.com -> eth_chainId 0x3909 (14601)
   viemChain.id                   14601
   SupportedChainId.SONIC_TESTNET 14601

3) approve step against a wallet on Sonic Testnet
   sent (no error)
```

## The change

Pin the id on the viem chain, the way `arcTestnetProxied` already overrides `rpcUrls`, so the chain object and `SupportedChainId.SONIC_TESTNET` cannot drift apart again. Name, RPC, explorer and native currency stay viem's. Nothing else in `CHAIN_CONFIGS` changes.

Checked with `npm run lint` and `npm run build`.