### PR TITLE
fix: switch the wallet when the chain is already added

### DIFF
--- a/src/lib/browser-wallets.ts
+++ b/src/lib/browser-wallets.ts
@@ -297,6 +297,17 @@ export async function disconnectAptosWallet(
   await connection?.disconnect();
 }
 
+/** EIP-1193 error for a chain the wallet does not recognise yet. */
+const CHAIN_NOT_ADDED = 4902;
+
+function errorCode(error: unknown): number | undefined {
+  const e = error as {
+    code?: number;
+    data?: { originalError?: { code?: number } };
+  };
+  return e?.code ?? e?.data?.originalError?.code;
+}
+
 export async function ensureEvmChain(
   provider: EvmProvider,
   chainId: SupportedChainId
@@ -308,20 +319,33 @@ export async function ensureEvmChain(
 
   const hexChainId = `0x${chainId.toString(16)}`;
 
-  await provider.request({
-    method: "wallet_addEthereumChain",
-    params: [
-      {
-        chainId: hexChainId,
-        chainName: chain.name,
-        nativeCurrency: chain.nativeCurrency,
-        rpcUrls: chain.rpcUrls.default.http,
-        blockExplorerUrls: chain.blockExplorers
-          ? Object.values(chain.blockExplorers).map(({ url }) => url)
-          : undefined,
-      },
-    ],
-  });
+  try {
+    await provider.request({
+      method: "wallet_switchEthereumChain",
+      params: [{ chainId: hexChainId }],
+    });
+  } catch (error: unknown) {
+    // Anything other than "chain not added" is the user's answer, including a
+    // 4001 rejection that the caller surfaces in the banner.
+    if (errorCode(error) !== CHAIN_NOT_ADDED) {
+      throw error;
+    }
+
+    await provider.request({
+      method: "wallet_addEthereumChain",
+      params: [
+        {
+          chainId: hexChainId,
+          chainName: chain.name,
+          nativeCurrency: chain.nativeCurrency,
+          rpcUrls: chain.rpcUrls.default.http,
+          blockExplorerUrls: chain.blockExplorers
+            ? Object.values(chain.blockExplorers).map(({ url }) => url)
+            : undefined,
+        },
+      ],
+    });
+  }
 
   const activeChainId = (await provider.request({ method: "eth_chainId" })) as string;
   if (parseInt(activeChainId, 16) !== chainId) {


### PR DESCRIPTION
## What

#132 replaced `wallet_switchEthereumChain` with `wallet_addEthereumChain` so that

> wallets can add and switch to chains (e.g. Arc Testnet) that are not pre-configured

That holds while the chain is not pre-configured. Once it is, `wallet_addEthereumChain` resolves as a no-op — MetaMask does not re-prompt for a chain it already has — and the wallet stays on whatever chain it was on. The `eth_chainId` check immediately after then fails:

```
Wallet is not on Arc Testnet. Please switch to it and retry.
```

## When it bites

`executeTransfer` switches chains three times:

| line | switches to | when |
|---|---|---|
| `use-cross-chain-transfer.ts:224` | source | approve |
| `use-cross-chain-transfer.ts:291` | source | burn |
| `use-cross-chain-transfer.ts:620` | **destination** | mint |

By the mint step the source chain is in the wallet, and the destination chain is too if the user has ever transferred there before. So:

- **First transfer to a given destination** — the destination chain is unknown to the wallet, `wallet_addEthereumChain` adds and switches, mint proceeds.
- **Every later transfer to that destination** — the chain is already there, the call does nothing, the wallet is still on the source chain, and mint stops with the message above.

The user is asked to switch by hand mid-transfer, in the app that just asked their wallet to switch.

## Fix

Try `wallet_switchEthereumChain` first, and fall back to `wallet_addEthereumChain` on `4902`, which is the code that method exists to signal. This keeps the behaviour #132 wanted for chains the wallet does not have, and adds the switch for the ones it does.

Errors other than `4902` are rethrown unchanged, so the `4001` rejection that `switchEvmWalletToChain` turns into a banner message still reaches it. The `eth_chainId` verification after the prompt is untouched, so a wallet that adds without switching still produces the manual-switch message rather than proceeding on the wrong chain.

`4902` is read from `error.code` and from `error.data.originalError.code`, since providers that wrap the RPC error nest it there.

## Checks

`npm run lint` reports only the pre-existing `react-hooks/exhaustive-deps` warning in `page.tsx`. `npx tsc --noEmit` is clean. The repository has no test runner, so there is nothing to add a case to; happy to add coverage if you would like a harness introduced separately.