### PR TITLE
fix: surface reverted EVM approve and burn transactions

### DIFF
--- a/src/hooks/use-cross-chain-transfer.ts
+++ b/src/hooks/use-cross-chain-transfer.ts
@@ -253,10 +253,13 @@ export function useCrossChainTransfer() {
     });
 
     addLog(`USDC Approval Tx: ${tx}`);
-    await createPublicClient({
+    const receipt = await createPublicClient({
       chain: CHAIN_CONFIGS[sourceChainId as SupportedChainId].viemChain,
       transport: http(),
     }).waitForTransactionReceipt({ hash: tx });
+    if (receipt.status !== "success") {
+      throw new Error(`USDC approval transaction reverted: ${tx}`);
+    }
     return tx;
   };
 
@@ -364,10 +367,13 @@ export function useCrossChainTransfer() {
     });
 
     addLog(`Burn Tx: ${tx}`);
-    await createPublicClient({
+    const receipt = await createPublicClient({
       chain: CHAIN_CONFIGS[sourceChainId as SupportedChainId].viemChain,
       transport: http(),
     }).waitForTransactionReceipt({ hash: tx });
+    if (receipt.status !== "success") {
+      throw new Error(`Burn transaction reverted: ${tx}`);
+    }
     return tx;
   };
 


### PR DESCRIPTION
## Problem

A reverted `approve` or `depositForBurn` on an EVM source chain is treated as a success. The UI then advances to *Attestation* and hangs there forever — no error, no failed step, and the transfer log's last line is a burn hash for a transaction that never burned anything.

Reproduction from the shipped UI (no code changes needed):

1. Connect an EVM wallet on any EVM source chain.
2. Enter an amount larger than the USDC balance shown under the field. The `max` attribute on the amount `<input>` is advisory only — `Start Transfer` is enabled whenever `parseFloat(amount) > 0` ([`page.tsx#L461`](https://github.com/circlefin/circle-cctp-crosschain-transfer/blob/master/src/app/page.tsx#L461)).
3. Approve both wallet prompts.

Observed: `approve` succeeds (ERC-20 `approve` never checks balance), `depositForBurn` reverts on the USDC `transferFrom`, and the app still logs `Burn Tx: 0x…` and moves to *Attestation*, where it polls IRIS every 5s indefinitely.

Expected: the flow stops with `Burn transaction reverted: 0x…`.

## Root cause

viem's `waitForTransactionReceipt` **resolves** with `receipt.status === "reverted"` for a reverted transaction; it does not throw. Both source-chain steps discard the receipt:

```ts
// approveEvmUsdc — src/hooks/use-cross-chain-transfer.ts#L256
await createPublicClient({ ... }).waitForTransactionReceipt({ hash: tx });
return tx;

// burnEvmUsdc — src/hooks/use-cross-chain-transfer.ts#L367
await createPublicClient({ ... }).waitForTransactionReceipt({ hash: tx });
return tx;
```

Verified against Sepolia with a real reverted transaction ([`0x34d5bda8…f5434c`](https://sepolia.etherscan.io/tx/0x34d5bda8604597dd4d3e4602311eb85000933d329ebe5af6942b9696bef5434c)):

```
waitForTransactionReceipt threw? false
receipt.status = reverted
```

`burnEvmUsdc` returns that hash to `retrieveAttestation`, which is where it turns into a permanent hang. IRIS has no message for a tx that emitted no `MessageSent`, so it answers `404` — and the `404` branch of the `while (true)` loop `continue`s without logging ([`#L581`](https://github.com/circlefin/circle-cctp-crosschain-transfer/blob/master/src/hooks/use-cross-chain-transfer.ts#L581)). Confirmed against the sandbox API with that same hash:

```
GET /v2/messages/0?transactionHash=0x34d5bda8…  ->  404 {"error":"Message not found for provided parameters"}   (x3)
```

Not a hypothetical revert either — the exact `depositForBurn` calldata this hook builds, simulated via `eth_call` for a caller with an allowance but no balance:

```
depositForBurn REVERTS: Execution reverted with reason: ERC20: transfer amount exceeds balance.
```

A second reachable path: any typed amount under `0.000001` (e.g. `0.0000001`) passes the `parseFloat(amount) > 0` guard, truncates to `0` through `parseUnits(amount, 6)`, and reverts with `Amount must be nonzero` — same silent hang today.

The destination side already handles this correctly; #126 added a `receipt.status !== "success"` check to `mintEvmUsdc`. The source side was never given the same treatment.

## Solution

Keep the receipt and check it, in the two places that were missing it:

```ts
const receipt = await createPublicClient({ ... }).waitForTransactionReceipt({ hash: tx });
if (receipt.status !== "success") {
  throw new Error(`Burn transaction reverted: ${tx}`);
}
```

The throw propagates to `executeTransfer`'s existing `catch`, which sets `currentStep` to `"error"` and shows the message — the same handling every other failure in the hook already gets. No new state, no new dependency, no behaviour change on the success path.

Scope is EVM only, matching the layer that has the bug: Solana burns go through Anchor's `sendAndConfirm`, which throws on a failed transaction, and Aptos submits via `waitForTransaction`, which defaults to `checkSuccess: true` and throws `FailedTransactionError`. Both already fail loudly.

## Testing

- `npm run lint` — clean (only the pre-existing `react-hooks/exhaustive-deps` warning in `page.tsx`, untouched by this PR).
- `npm run build` — passes, including the TypeScript pass.
- Verified `waitForTransactionReceipt` resolves rather than throws on a real reverted Sepolia transaction (output above), which is the premise of the fix.
- Verified IRIS returns a persistent `404` for a hash carrying no CCTP message, which is why the old behaviour hangs instead of erroring.
- Verified `depositForBurn` reverts under the balance/allowance state the UI permits, and that `depositForBurn(0)` reverts with `Amount must be nonzero`.

Verification used throwaway scripts against public Sepolia RPC and the IRIS sandbox; they are not part of the diff.

## Impact

- A failed approve or burn now surfaces as an error instead of an indefinite *Waiting for attestation* spinner.
- 8 added lines, 2 removed, one file. No API or config change.
- Success path is byte-identical; only reverted transactions take a different branch.
